### PR TITLE
docs: add default repository setup and troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,28 @@ npx ts-node index.ts
 npx tsc && node dist/index.js
 ```
 
+## Cursor Cloud Agent Setup
+
+If you use Cursor Cloud Agents from Linear, GitHub, or the dashboard, configure a default repository first.
+
+### Set a default repository
+
+1. Open the Cursor dashboard: <https://www.cursor.com/dashboard?tab=cloud-agents>
+2. In **Cloud Agents**, locate **Default Repository**
+3. Enter your repository in `owner/repo` format (for example, `gakshita/Agents`)
+4. (Optional) Set a default branch such as `main`
+5. Save settings and run your agent again
+
+### Troubleshooting
+
+- **`no_default_repository` / "No default repository configured"**
+  - Add a repository in the Cloud Agents dashboard and save
+- **"Could not access repository `<owner>/<repo>`"**
+  - Confirm the repository name is correct
+  - Confirm the repository still exists and was not renamed
+  - Reconnect GitHub/GitLab integration in your Cursor dashboard
+  - Verify the connected account has access to the repository (including private repos/org permissions)
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new **Cursor Cloud Agent Setup** section to `README.md`
- document step-by-step instructions to configure a default repository in Cursor dashboard
- add troubleshooting guidance for:
  - `no_default_repository` / "No default repository configured"
  - "Could not access repository `<owner>/<repo>`"

## Why
The linked issue history repeatedly asks how to configure a default repository and shows confusion around repository-access errors. This change adds a canonical, in-repo guide so users can self-serve the setup and fixes quickly.

## Testing
- documentation-only change; no runtime code paths affected
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [PRA-12](https://linear.app/prash-sandbox/issue/PRA-12/asdfjasjdfs)

<div><a href="https://cursor.com/agents/bc-821f01e1-8ac6-4f15-a613-c91808fc2605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-821f01e1-8ac6-4f15-a613-c91808fc2605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

